### PR TITLE
Fix strict error.

### DIFF
--- a/src/Http/Adapter/TwitterStream.php
+++ b/src/Http/Adapter/TwitterStream.php
@@ -2,8 +2,8 @@
 
 namespace CvoTechnologies\Twitter\Http\Adapter;
 
+use Cake\Http\Client\Request;
 use Cake\Network\Http\Adapter\Stream;
-use Cake\Network\Http\Request;
 use Cake\Network\Http\Response;
 
 class TwitterStream extends Stream


### PR DESCRIPTION
Resolves https://github.com/CVO-Technologies/cakephp-twitter/issues/10

But wasn't this supposed to be BC inside 3.4?
Did we maybe forgot some class aliases here?