### PR TITLE
Fix for CakePHP 3.5.x

### DIFF
--- a/src/Http/Adapter/TwitterStream.php
+++ b/src/Http/Adapter/TwitterStream.php
@@ -2,9 +2,9 @@
 
 namespace CvoTechnologies\Twitter\Http\Adapter;
 
+use Cake\Http\Client\Adapter\Stream;
 use Cake\Http\Client\Request;
-use Cake\Network\Http\Adapter\Stream;
-use Cake\Network\Http\Response;
+use Cake\Http\Client\Response;
 
 class TwitterStream extends Stream
 {


### PR DESCRIPTION
I've popped in a change for the latest version of CakePHP - 3.5.x. to remove the strict warnings.